### PR TITLE
Use valueFromItems to set value if value not specified otherwise

### DIFF
--- a/template.js
+++ b/template.js
@@ -266,6 +266,7 @@ function addEcommerceData(eventData, mappedData) {
     if (eventData['x-ga-mp1-ev']) mappedData.custom_data.value = eventData['x-ga-mp1-ev'];
     else if (eventData['x-ga-mp1-tr']) mappedData.custom_data.value = eventData['x-ga-mp1-tr'];
     else if (eventData.value) mappedData.custom_data.value = eventData.value;
+    else if (valueFromItems) mappedData.custom_data.value = valueFromItems;
 
     if (eventData.currency) mappedData.custom_data.currency = eventData.currency;
     else if (currencyFromItems) mappedData.custom_data.currency = currencyFromItems;


### PR DESCRIPTION
Thank you for your work on this tag! I've found it very helpful so far. 

I noticed that the `value` wasn't coming through in my add to cart event. Our app should probably be setting this value when it sends the event -- but I noticed that the code _does_ add up the prices of the items in `valueFromItems`, but doesn't seem to use it.

So this PR makes use of that tally (`valueFromItems`) and sets the `value` attribute only if it wasn't set otherwise. 

This change seems to work for me, and thought I'd share in case you'd like to incorporate it. 

Thank you!