### PR TITLE
Tag display name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 ## How to use Pinterest tag
 
----
-**Event Name Setup Method** - select from a list of standard events, add a custom event, or choose to Inherit an event name from a client. When Inherit from client is selected, the Pinterest CAPI tag will try to map events automatically into standard events or use a custom name if it’s impossible to map into a starred event.
+**Event Name Setup Method** - select from a list of standard events, add a custom event, or choose to Inherit an event name from a client. When `Inherit from client` is selected, the Pinterest CAPI tag will try to map events automatically into standard events or use a custom name if it’s impossible to map into a starred event.
 
-**Pinterest Advertiser ID** - You can find it by logging into the Pinterest account that owns your advertiser account, then going to "ads.pinterest.com." In the top navigation section, click "Viewing: " and the advertiser id will be the number underneath the ad account name in the drop-down menu. If your Pinterest account has multiple ad accounts, make sure you are choosing the proper one that you want to use for owning your API conversion events. Another way to confirm your advertiser id is to navigate to Ads > Overview and look for the id in the URL path. It will look like: "ads.pinterest.com/advertiser/ADVERTISER_ID/?...".
+**Pinterest Advertiser ID** - You can find it by logging into the Pinterest account that owns your advertiser account, then going to "ads.pinterest.com." In the top navigation section, click "Viewing: " and the Advertiser ID will be the number underneath the ad account name in the drop-down menu. If your Pinterest account has multiple ad accounts, make sure you are choosing the proper one that you want to use for owning your API conversion events. Another way to confirm your Advertiser ID is to navigate to _Ads > Overview_ and look for the ID in the URL path. It will look like: `ads.pinterest.com/advertiser/ADVERTISER_ID/?...`.
 
 **Test request** - The events will not be recorded, but the API will still return the same response messages. Use this mode to verify your requests are working and that your events are constructed correctly.
 
@@ -15,17 +14,18 @@
 
 **Custom Data** - select from a list of product data.
 
-**Logs Settings** - choose if you want to log requests to your stape account. This feature is handy when setting up server-side tagging since it allows seeing incoming and outgoing requests and network responses.
+**Logs Settings** - choose if you want to log requests to your Stape account. This feature is handy when setting up server-side tagging since it allows seeing incoming and outgoing requests and network responses.
 
-## Benefits of Pinterest tag:
+## Benefits of Pinterest tag
 - Supports event deduplication.
 - Supports standard and custom events.
 - Supports real-time server event testing.
-- Does not require Access Token. You should use only a Pinterest advertiser ID.
+- Does not require Access Token. You should use only a Pinterest Advertiser ID.
 - You can send event and product data.
 
-## Useful link:
-- https://stape.io/blog/pinterest-conversion-api 
+## Useful resource
+- https://stape.io/blog/pinterest-conversion-api
+
 ## Open Source
 
-Pinterest Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+Pinterest Tag for GTM Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 4f09aba28bee2c9217b746288f87f5bcef55ab13
+    changeNotes: Changed the tag display name.
   - sha: a6b445f9182e7c92ead9a59dd3e024ee0b577645
     changeNotes: Added common cookie support.
   - sha: bbc071dd2bc6b119e60c3ec5ed5a85e4fc7fcaca

--- a/template.tpl
+++ b/template.tpl
@@ -13,7 +13,7 @@ ___INFO___
   "id": "cvt_temp_public_id",
   "version": 1,
   "securityGroups": [],
-  "displayName": "Pinterest Conversion API",
+  "displayName": "Pinterest Conversion API by Stape",
   "categories": [
     "ADVERTISING",
     "ANALYTICS",


### PR DESCRIPTION
Hi.

Changed the tag display name from **Pinterest Conversion API** to **Pinterest Conversion API by Stape**.

I made some minor adjustments in the README as well.