### PR TITLE
Fix Click ID cookie creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pinterest Conversion API Tag for Google Tag Manager Server Container
 
-## How to use Pinterest tag
+## How to use Pinterest Conversion API
 
-**Event Name Setup Method** - select from a list of standard events, add a custom event, or choose to Inherit an event name from a client. When `Inherit from client` is selected, the Pinterest CAPI tag will try to map events automatically into standard events or use a custom name if it’s impossible to map into a starred event.
+**Event Name Setup Method** - select from a list of standard events, add a custom event, or choose to Inherit an event name from a client. When `Inherit from client` is selected, the Pinterest CAPI tag will try to map events automatically into standard events or use `custom` as event name if it’s impossible to map into a known event.
 
-**Pinterest Advertiser ID** - You can find it by logging into the Pinterest account that owns your advertiser account, then going to "ads.pinterest.com." In the top navigation section, click "Viewing: " and the Advertiser ID will be the number underneath the ad account name in the drop-down menu. If your Pinterest account has multiple ad accounts, make sure you are choosing the proper one that you want to use for owning your API conversion events. Another way to confirm your Advertiser ID is to navigate to _Ads > Overview_ and look for the ID in the URL path. It will look like: `ads.pinterest.com/advertiser/ADVERTISER_ID/?...`.
+**Pinterest Advertiser ID** - You can find it by logging into the Pinterest account that owns your advertiser account, then going to `ads.pinterest.com`. In the top navigation section, click _"Viewing:"_. The Advertiser ID will be the number underneath the ad account name in the drop-down menu. If your Pinterest account has multiple ad accounts, make sure you are choosing the proper one that you want to use for owning your API conversion events. Another way to confirm your Advertiser ID is to navigate to _Ads > Overview_ and look for the ID in the URL path. It will look like: `ads.pinterest.com/advertiser/ADVERTISER_ID/?...`.
 
 **Test request** - The events will not be recorded, but the API will still return the same response messages. Use this mode to verify your requests are working and that your events are constructed correctly.
 
@@ -20,7 +20,6 @@
 - Supports event deduplication.
 - Supports standard and custom events.
 - Supports real-time server event testing.
-- Does not require Access Token. You should use only a Pinterest Advertiser ID.
 - You can send event and product data.
 
 ## Useful resource
@@ -28,4 +27,4 @@
 
 ## Open Source
 
-Pinterest Tag for GTM Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+The **Pinterest Conversion API** for GTM Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 82391a35266feb7b3757cac057e34b855c7a3e3d
+    changeNotes: Fix for extracting the Click ID from the incoming request.
   - sha: a7402a470534442a3c03064f48f62c93c2e1c71d
     changeNotes: Fixed errors with wrong event name, updated log flow.
   - sha: 4f09aba28bee2c9217b746288f87f5bcef55ab13

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 1897f704729b2eb4b7231f599902f1467ef9305d
+  - sha: fc3516a81d737b728e44588984d832a5521ce2a2
     changeNotes: Fix for extracting the Click ID from the incoming request.
   - sha: a7402a470534442a3c03064f48f62c93c2e1c71d
     changeNotes: Fixed errors with wrong event name, updated log flow.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 82391a35266feb7b3757cac057e34b855c7a3e3d
+  - sha: 1897f704729b2eb4b7231f599902f1467ef9305d
     changeNotes: Fix for extracting the Click ID from the incoming request.
   - sha: a7402a470534442a3c03064f48f62c93c2e1c71d
     changeNotes: Fixed errors with wrong event name, updated log flow.

--- a/template.js
+++ b/template.js
@@ -10,7 +10,7 @@ const getRequestHeader = require('getRequestHeader');
 const getType = require('getType');
 const makeString = require('makeString');
 const makeInteger = require('makeInteger');
-const getRequestQueryParameter = require('getRequestQueryParameter');
+const parseUrl = require('parseUrl');
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 
@@ -436,34 +436,35 @@ function log(logObject) {
   if (isLoggingEnabled) {
     logToConsole(JSON.stringify(logObject));
   }
- }
- 
- function determinateIsLoggingEnabled() {
-    const containerVersion = getContainerVersion();
-    const isDebug = !!(
-        containerVersion &&
-        (containerVersion.debugMode || containerVersion.previewMode)
-    );
- 
-    if (!data.logType) {
-        return isDebug;
-    }
- 
-    if (data.logType === 'no') {
-        return false;
-    }
- 
-    if (data.logType === 'debug') {
-        return isDebug;
-    }
- 
-    return data.logType === 'always';
- }
+}
+
+function determinateIsLoggingEnabled() {
+  const containerVersion = getContainerVersion();
+  const isDebug = !!(
+    containerVersion &&
+    (containerVersion.debugMode || containerVersion.previewMode)
+  );
+
+  if (!data.logType) {
+    return isDebug;
+  }
+
+  if (data.logType === 'no') {
+    return false;
+  }
+
+  if (data.logType === 'debug') {
+    return isDebug;
+  }
+
+  return data.logType === 'always';
+}
 
 function setClickIdCookieIfNeeded() {
-  const click_id = getRequestQueryParameter('epik');
-  if (click_id) {
-    setCookie('_epik', click_id, {
+  const url = eventData.page_location || getRequestHeader('referer');
+  const searchParams = parseUrl(url).searchParams;
+  if (searchParams && searchParams.epik) {
+    setCookie('_epik', searchParams.epik, {
       domain: 'auto',
       path: '/',
       secure: true,

--- a/template.js
+++ b/template.js
@@ -467,8 +467,9 @@ function setClickIdCookieIfNeeded() {
     setCookie('_epik', searchParams.epik, {
       domain: 'auto',
       path: '/',
+      samesite: 'Lax',
       secure: true,
-      httpOnly: true,
+      httpOnly: false,
       'max-age': 31536000, // 1 year
     });
   }

--- a/template.tpl
+++ b/template.tpl
@@ -508,7 +508,7 @@ const getRequestHeader = require('getRequestHeader');
 const getType = require('getType');
 const makeString = require('makeString');
 const makeInteger = require('makeInteger');
-const getRequestQueryParameter = require('getRequestQueryParameter');
+const parseUrl = require('parseUrl');
 const setCookie = require('setCookie');
 const getCookieValues = require('getCookieValues');
 
@@ -959,9 +959,10 @@ function determinateIsLoggingEnabled() {
 }
 
 function setClickIdCookieIfNeeded() {
-  const click_id = getRequestQueryParameter('epik');
-  if (click_id) {
-    setCookie('_epik', click_id, {
+  const url = eventData.page_location || getRequestHeader('referer');
+  const searchParams = parseUrl(url).searchParams;
+  if (searchParams && searchParams.epik) {
+    setCookie('_epik', searchParams.epik, {
       domain: 'auto',
       path: '/',
       secure: true,
@@ -1318,5 +1319,4 @@ setup: ''
 ___NOTES___
 
 Created on 18/07/2022, 19:04:12
-
 

--- a/template.tpl
+++ b/template.tpl
@@ -965,8 +965,9 @@ function setClickIdCookieIfNeeded() {
     setCookie('_epik', searchParams.epik, {
       domain: 'auto',
       path: '/',
+      samesite: 'Lax',
       secure: true,
-      httpOnly: true,
+      httpOnly: false,
       'max-age': 31536000, // 1 year
     });
   }

--- a/template.tpl
+++ b/template.tpl
@@ -1121,7 +1121,7 @@ ___SERVER_PERMISSIONS___
                 "mapValue": [
                   {
                     "type": 1,
-                    "string": "x-ga-gcs"
+                    "string": "referer"
                   }
                 ]
               }


### PR DESCRIPTION
Hi.

- Updated the `README.md` because there were some inconsistencies.
- Changed the source for extracting the `epik` URL query parameter. Previously, it was reading the incoming request URL, which may not always make sense. Now, it extracts from the `page_location` Event Data parameter, or the `referer` request header. [[1]](https://github.com/stape-io/pinterest-tag/pull/16/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R464-R466)
- The Click ID cookie is not HttpOnly anymore because it needs to be accessed on the client-side. [[1]](https://github.com/stape-io/pinterest-tag/pull/16/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R470-R472)
- Removed unused allowed request header. [[1]](https://github.com/stape-io/pinterest-tag/pull/16/files#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L1123)